### PR TITLE
(Dan) Support for time-based and manual log file rotation.

### DIFF
--- a/v2/slogger/logger.go
+++ b/v2/slogger/logger.go
@@ -17,7 +17,6 @@ package slogger
 import (
 	"errors"
 	"fmt"
-	"os"
 	"runtime"
 	"strings"
 	"time"
@@ -325,12 +324,12 @@ func (self *StackError) Error() string {
 
 func stripDirectories(filepath string, toKeep int) string {
 	var idxCutoff int
-	if idxCutoff = strings.LastIndex(filepath, string(os.PathSeparator)); idxCutoff == -1 {
+	if idxCutoff = strings.LastIndex(filepath, string('/')); idxCutoff == -1 {
 		return filepath
 	}
 
 	for dirToKeep := 0; dirToKeep < toKeep; dirToKeep++ {
-		switch idx := strings.LastIndex(filepath[:idxCutoff], string(os.PathSeparator)); idx {
+		switch idx := strings.LastIndex(filepath[:idxCutoff], string('/')); idx {
 		case -1:
 			break
 		default:

--- a/v2/slogger/logger.go
+++ b/v2/slogger/logger.go
@@ -324,6 +324,9 @@ func (self *StackError) Error() string {
 
 func stripDirectories(filepath string, toKeep int) string {
 	var idxCutoff int
+
+	// Look for forward slashes ('/') regardless of OS because the Go
+	// runtime uses forward slashes regardless of OS
 	if idxCutoff = strings.LastIndex(filepath, string('/')); idxCutoff == -1 {
 		return filepath
 	}

--- a/v2/slogger/rolling_file_appender/error.go
+++ b/v2/slogger/rolling_file_appender/error.go
@@ -101,3 +101,39 @@ func IsWriteError(err error) bool {
 	_, ok := err.(WriteError)
 	return ok
 }
+
+type EncodeError struct {
+	Filename string
+	Err      error
+}
+
+func (self EncodeError) Error() string {
+	return fmt.Sprintf(
+		"rolling_file_appender: Failed to encode state to %s: %s",
+		self.Filename,
+		self.Err.Error(),
+	)
+}
+
+func IsEncodeError(err error) bool {
+	_, ok := err.(EncodeError)
+	return ok
+}
+
+type DecodeError struct {
+	Filename string
+	Err      error
+}
+
+func (self DecodeError) Error() string {
+	return fmt.Sprintf(
+		"rolling_file_appender: Failed to decode state from %s: %s",
+		self.Filename,
+		self.Err.Error(),
+	)
+}
+
+func IsDecodeError(err error) bool {
+	_, ok := err.(DecodeError)
+	return ok
+}

--- a/v2/slogger/rolling_file_appender/error.go
+++ b/v2/slogger/rolling_file_appender/error.go
@@ -1,0 +1,99 @@
+package rolling_file_appender
+
+type CloseError struct {
+	Filename string
+	Err      error
+}
+
+func (self CloseError) Error() string {
+	return fmt.Sprintf(
+		"rolling_file_appender: Failed to close %s: %s",
+		self.Filename,
+		self.Err.Error(),
+	)
+}
+
+func IsCloseError(err error) bool {
+	_, ok := err.(CloseError)
+	return ok
+}
+
+type MinorRotationError struct {
+	Err error
+}
+
+func (self MinorRotationError) Error() string {
+	return ("rolling_file_appender: minor error while rotating logs: " + self.Err.Error())
+}
+
+func IsMinorRotationError(err error) bool {
+	_, ok := err.(MinorRotationError)
+	return ok
+}
+
+type NoFileError struct{}
+
+func (NoFileError) Error() string {
+	return "rolling_file_appender: No log file to write to"
+}
+
+func IsNoFileError(err error) bool {
+	_, ok := err.(NoFileError)
+	return ok
+}
+
+type OpenError struct {
+	Filename string
+	Err      error
+}
+
+func (self OpenError) Error() string {
+	return fmt.Sprintf(
+		"rolling_file_appender: Failed to open %s: %s",
+		self.Filename,
+		self.Err.Error(),
+	)
+}
+
+func IsOpenError(err error) bool {
+	_, ok := err.(OpenError)
+	return ok
+}
+
+type RenameError struct {
+	OldFilename string
+	NewFilename string
+	Err         error
+}
+
+func (self RenameError) Error() string {
+	return fmt.Sprintf(
+		"rolling_file_appender: Failed to rename %s to %s: %s",
+		self.OldFilename,
+		self.NewFilename,
+		self.Err.Error(),
+	)
+}
+
+func IsRenameError(err error) bool {
+	_, ok := err.(RenameError)
+	return ok
+}
+
+type WriteError struct {
+	Filename string
+	Err      error
+}
+
+func (self WriteError) Error() string {
+	return fmt.Sprintf(
+		"rolling_file_appender: Failed to write to %s: %s",
+		self.Filename,
+		self.Err.Error(),
+	)
+}
+
+func IsWriteError(err error) bool {
+	_, ok := err.(WriteError)
+	return ok
+}

--- a/v2/slogger/rolling_file_appender/error.go
+++ b/v2/slogger/rolling_file_appender/error.go
@@ -1,5 +1,9 @@
 package rolling_file_appender
 
+import (
+	"fmt"
+)
+
 type CloseError struct {
 	Filename string
 	Err      error

--- a/v2/slogger/rolling_file_appender/error.go
+++ b/v2/slogger/rolling_file_appender/error.go
@@ -137,3 +137,21 @@ func IsDecodeError(err error) bool {
 	_, ok := err.(DecodeError)
 	return ok
 }
+
+type StatError struct {
+	Filename string
+	Err      error
+}
+
+func (self StatError) Error() string {
+	return fmt.Sprintf(
+		"rolling_file_appender: Failed to stat %s: %s",
+		self.Filename,
+		self.Err.Error(),
+	)
+}
+
+func IsStatError(err error) bool {
+	_, ok := err.(StatError)
+	return ok
+}

--- a/v2/slogger/rolling_file_appender/hidden_unix.go
+++ b/v2/slogger/rolling_file_appender/hidden_unix.go
@@ -1,0 +1,11 @@
+// +build !windows
+
+package rolling_file_appender
+
+import (
+	"os"
+)
+
+func createHidden(path string) (*os.File, error) {
+	return os.Create(path)
+}

--- a/v2/slogger/rolling_file_appender/hidden_windows.go
+++ b/v2/slogger/rolling_file_appender/hidden_windows.go
@@ -1,0 +1,27 @@
+// +build windows
+
+package rolling_file_appender
+
+import (
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+func createHidden(name string) (*os.File, error) {
+	var sa syscall.SecurityAttributes
+	sa.Length = uint32(unsafe.Sizeof(sa))
+	sa.InheritHandle = 1
+	handle, err := syscall.CreateFile(
+		syscall.StringToUTF16Ptr(name),
+		syscall.GENERIC_READ|syscall.GENERIC_WRITE,
+		syscall.FILE_SHARE_READ|syscall.FILE_SHARE_WRITE,
+		&sa,
+		syscall.CREATE_ALWAYS,
+		syscall.FILE_ATTRIBUTE_HIDDEN,
+		0)
+	if err != nil {
+		return nil, err
+	}
+	return os.NewFile(uintptr(handle), name), nil
+}

--- a/v2/slogger/rolling_file_appender/rolling_file_appender.go
+++ b/v2/slogger/rolling_file_appender/rolling_file_appender.go
@@ -187,6 +187,13 @@ func (self *RollingFileAppender) Flush() error {
 	return self.file.Sync()
 }
 
+func (self *RollingFileAppender) Rotate() error {
+	self.lock.Lock()
+	defer self.lock.Unlock()
+
+	return self.rotate()
+}
+
 func rotatedFilename(baseFilename string, t time.Time, serial int) string {
 	filename := fmt.Sprintf(
 		"%s.%d-%02d-%02dT%02d-%02d-%02d",

--- a/v2/slogger/rolling_file_appender/rolling_file_appender.go
+++ b/v2/slogger/rolling_file_appender/rolling_file_appender.go
@@ -330,9 +330,3 @@ func (self *RollingFileAppender) rotationTimeSlice() (RotationTimeSlice, error) 
 
 	return rotationTimes, nil
 }
-
-func (self *RollingFileAppender) statePath() string {
-	// TODO: Port this to Windows so that the file is hidden there
-	newBase := ".slogger-state-" + filepath.Base(self.absPath)
-	return filepath.Join(filepath.Dir(self.absPath), newBase)
-}

--- a/v2/slogger/rolling_file_appender/rolling_file_appender.go
+++ b/v2/slogger/rolling_file_appender/rolling_file_appender.go
@@ -71,9 +71,9 @@ type RollingFileAppender struct {
 //
 // If both maxFileSize and maxDuration are set than the log file will
 // be rotated whenever either threshold is met.  The duration used to
-// determine whether to rotate a log file should be rotated due to
-// maxDuration being positive is reset regardless of why the log was
-// rotated previously.
+// determine whether a log file should be rotated (that is, the
+// duration compared to maxDuration) is reset regardless of why the
+// log was rotated previously.
 //
 // maxRotatedLogs specifies the maximum number of rotated logs allowed
 // before old logs are deleted.  Set to a non-positive number if you

--- a/v2/slogger/rolling_file_appender/rolling_file_appender.go
+++ b/v2/slogger/rolling_file_appender/rolling_file_appender.go
@@ -135,6 +135,7 @@ func NewWithStringWriter(filename string, maxFileSize int64, maxDuration time.Du
 
 		if stateExistsVar {
 			if err = appender.loadState(); err != nil {
+				appender.file.Close()
 				return nil, err
 			}
 		} else {

--- a/v2/slogger/rolling_file_appender/rolling_file_appender.go
+++ b/v2/slogger/rolling_file_appender/rolling_file_appender.go
@@ -159,7 +159,10 @@ func (self *RollingFileAppender) Append(log *slogger.Log) error {
 		return err
 	}
 
-	if self.maxFileSize > 0 && self.curFileSize > self.maxFileSize {
+	if (self.maxFileSize > 0 && self.curFileSize > self.maxFileSize) ||
+		(self.maxDuration > 0 &&
+			self.state != nil &&
+			time.Since(self.state.LogStartTime) > self.maxDuration) {
 		return self.rotate()
 	}
 

--- a/v2/slogger/rolling_file_appender/rolling_file_appender_test.go
+++ b/v2/slogger/rolling_file_appender/rolling_file_appender_test.go
@@ -155,6 +155,7 @@ func newAppenderAndLogger(test *testing.T, maxFileSize int64, maxRotatedLogs int
 	appender, err := New(
 		rfaTestLogPath,
 		maxFileSize,
+		0,
 		maxRotatedLogs,
 		rotateIfExists,
 		func() []string {

--- a/v2/slogger/rolling_file_appender/rolling_file_appender_test.go
+++ b/v2/slogger/rolling_file_appender/rolling_file_appender_test.go
@@ -138,6 +138,24 @@ func TestRotationTimeBased(test *testing.T) {
 	assertNumLogFiles(test, 3)
 }
 
+func TestRotationManual(test *testing.T) {
+	defer teardown()
+	appender, _ := setup(test, -1, 0, 10, false)
+	defer appender.Close()
+
+	assertNumLogFiles(test, 1)
+
+	if err := appender.Rotate(); err != nil {
+		test.Fatal("appender.Rotate() return an error: " + err.Error())
+	}
+	assertNumLogFiles(test, 2)
+
+	if err := appender.Rotate(); err != nil {
+		test.Fatal("appender.Rotate() return an error: " + err.Error())
+	}
+	assertNumLogFiles(test, 3)
+}
+
 func assertCurrentLogContains(test *testing.T, expected string) {
 	actual := readCurrentLog(test)
 

--- a/v2/slogger/rolling_file_appender/rolling_file_appender_test.go
+++ b/v2/slogger/rolling_file_appender/rolling_file_appender_test.go
@@ -188,7 +188,14 @@ func numLogFiles() (int, error) {
 		return -1, err
 	}
 
-	return len(filenames), nil
+	visibleFilenames := make([]string, 0, len(filenames)-1)
+	for _, filename := range filenames {
+		if !strings.HasPrefix(filename, ".") {
+			visibleFilenames = append(visibleFilenames, filename)
+		}
+	}
+
+	return len(visibleFilenames), nil
 }
 
 func readCurrentLog(test *testing.T) string {

--- a/v2/slogger/rolling_file_appender/rolling_file_appender_test.go
+++ b/v2/slogger/rolling_file_appender/rolling_file_appender_test.go
@@ -146,12 +146,12 @@ func TestRotationManual(test *testing.T) {
 	assertNumLogFiles(test, 1)
 
 	if err := appender.Rotate(); err != nil {
-		test.Fatal("appender.Rotate() return an error: " + err.Error())
+		test.Fatal("appender.Rotate() returned an error: " + err.Error())
 	}
 	assertNumLogFiles(test, 2)
 
 	if err := appender.Rotate(); err != nil {
-		test.Fatal("appender.Rotate() return an error: " + err.Error())
+		test.Fatal("appender.Rotate() returned an error: " + err.Error())
 	}
 	assertNumLogFiles(test, 3)
 }

--- a/v2/slogger/rolling_file_appender/rotation_time.go
+++ b/v2/slogger/rolling_file_appender/rotation_time.go
@@ -1,0 +1,60 @@
+package rolling_file_appender
+
+type RotationTime struct {
+	Time     time.Time
+	Serial   int
+	Filename string
+}
+
+type RotationTimeSlice [](*RotationTime)
+
+func (self RotationTimeSlice) Len() int {
+	return len(self)
+}
+
+func (self RotationTimeSlice) Less(i, j int) bool {
+	if self[i].Time == self[j].Time {
+		return self[i].Serial < self[j].Serial
+	}
+
+	return self[i].Time.Before(self[j].Time)
+}
+
+func (self RotationTimeSlice) Swap(i, j int) {
+	self[i], self[j] = self[j], self[i]
+}
+
+var rotatedTimeRegExp = regexp.MustCompile(`\.(\d+-\d\d-\d\dT\d\d-\d\d-\d\d)(-(\d+))?$`)
+
+func extractRotationTimeFromFilename(filename string) (*RotationTime, error) {
+	match := rotatedTimeRegExp.FindStringSubmatch(filename)
+
+	if match == nil {
+		return nil, fmt.Errorf("Filename does not match rotation time format: %s", filename)
+	}
+
+	rotatedTime, err := time.Parse("2006-01-02T15-04-05", match[1])
+	if err != nil {
+		return nil, fmt.Errorf(
+			"Time %s in filename %s did not parse: %v",
+			match[1],
+			filename,
+			err,
+		)
+	}
+
+	serial := 0
+	if match[3] != "" {
+		serial, err = strconv.Atoi(match[3])
+
+		if err != nil {
+			return nil, fmt.Errorf(
+				"Could not parse serial number in filename %s: %v",
+				filename,
+				err,
+			)
+		}
+	}
+
+	return &RotationTime{rotatedTime, serial, filename}, nil
+}

--- a/v2/slogger/rolling_file_appender/rotation_time.go
+++ b/v2/slogger/rolling_file_appender/rotation_time.go
@@ -1,5 +1,12 @@
 package rolling_file_appender
 
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"time"
+)
+
 type RotationTime struct {
 	Time     time.Time
 	Serial   int

--- a/v2/slogger/rolling_file_appender/state.go
+++ b/v2/slogger/rolling_file_appender/state.go
@@ -1,5 +1,53 @@
 package rolling_file_appender
 
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"time"
+)
+
 type state struct {
-	path string
+	LogStartTime time.Time
+}
+
+func newState(logStartTime time.Time) *state {
+	return &state{logStartTime}
+}
+
+func readState(path string) (*state, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, OpenError{path, err}
+	}
+
+	var decodedState *state
+	decoder := json.NewDecoder(file)
+	if err = decoder.Decode(&decodedState); err != nil {
+		return nil, DecodeError{path, err}
+	}
+
+	return decodedState, nil
+}
+
+func (self *state) write(path string) error {
+	// TODO: On windows we should make the file hidden
+	file, err := os.Create(path)
+	if err != nil {
+		return OpenError{path, err}
+	}
+	defer file.Close()
+
+	encoder := json.NewEncoder(file)
+	if err = encoder.Encode(self); err != nil {
+		return EncodeError{path, err}
+	}
+
+	return nil
+}
+
+func (self *RollingFileAppender) statePath() string {
+	// TODO: Port this to Windows so that the file is hidden there
+	newBase := ".slogger-state-" + filepath.Base(self.absPath)
+	return filepath.Join(filepath.Dir(self.absPath), newBase)
 }

--- a/v2/slogger/rolling_file_appender/state.go
+++ b/v2/slogger/rolling_file_appender/state.go
@@ -44,8 +44,7 @@ func stateExists(path string) (bool, error) {
 }
 
 func (self *state) write(path string) error {
-	// TODO: On windows we should make the file hidden
-	file, err := os.Create(path)
+	file, err := createHidden(path)
 	if err != nil {
 		return OpenError{path, err}
 	}
@@ -60,7 +59,6 @@ func (self *state) write(path string) error {
 }
 
 func (self *RollingFileAppender) statePath() string {
-	// TODO: Port this to Windows so that the file is hidden there
 	newBase := ".slogger-state-" + filepath.Base(self.absPath)
 	return filepath.Join(filepath.Dir(self.absPath), newBase)
 }

--- a/v2/slogger/rolling_file_appender/state.go
+++ b/v2/slogger/rolling_file_appender/state.go
@@ -7,8 +7,14 @@ import (
 	"time"
 )
 
+// state is serialized to and deserialized from disk.  Changes to this
+// structure should be done in a backward-compatible fashion.  If new
+// fields are added here then they will be read in as the zero value
+// when reading in older versions of the state file.  Existing fields'
+// types should not be changed as that will break reading in older
+// versions of the state file.
 type state struct {
-	LogStartTime time.Time
+	LogStartTime time.Time `json:"logStartTime"`
 }
 
 func newState(logStartTime time.Time) *state {

--- a/v2/slogger/rolling_file_appender/state.go
+++ b/v2/slogger/rolling_file_appender/state.go
@@ -20,6 +20,7 @@ func readState(path string) (*state, error) {
 	if err != nil {
 		return nil, OpenError{path, err}
 	}
+	defer file.Close()
 
 	var decodedState *state
 	decoder := json.NewDecoder(file)
@@ -28,6 +29,18 @@ func readState(path string) (*state, error) {
 	}
 
 	return decodedState, nil
+}
+
+func stateExists(path string) (bool, error) {
+	if _, err := os.Stat(path); err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+
+		return false, StatError{path, err}
+	}
+
+	return true, nil
 }
 
 func (self *state) write(path string) error {

--- a/v2/slogger/rolling_file_appender/state.go
+++ b/v2/slogger/rolling_file_appender/state.go
@@ -1,0 +1,5 @@
+package rolling_file_appender
+
+type state struct {
+	path string
+}


### PR DESCRIPTION
This PR adds support for time-based and manual log file rotation to the RollingFileAppender.  Creation time of the logfile is stored in a hidden file in the same directory as the log file.

cc @dgottlieb 

cc @markbenvenuto and @dgolub for Windows-specific bits