### PR TITLE
CLOUDP-126300: Convert slogger to use go modules

### DIFF
--- a/v1/slogger/go.mod
+++ b/v1/slogger/go.mod
@@ -1,0 +1,3 @@
+module github.com/mongodb/slogger/v1/slogger
+
+go 1.18

--- a/v2/slogger/go.mod
+++ b/v2/slogger/go.mod
@@ -1,0 +1,3 @@
+module github.com/mongodb/slogger/v2/slogger
+
+go 1.18


### PR DESCRIPTION
[CLOUDP-126300](https://jira.mongodb.org/browse/CLOUDP-126300)

Converted both `v1` and `v2` directories to have a `go.mod` file. Per `go env`, value for `GO111MODULE` is `GO111MODULE=""`, which suggests that modules are enabled. Running `./run-tests` runs all tests without any complaints, and importing the top level `slogger/` project in GoLand also has no errors.

Please let me know if I should change the package structure to include a `src/` file to move both `v1` and `v2` into.

@TomerYakir 