### PR TITLE
Add the ability to compress log files upon rotation

### DIFF
--- a/v2/slogger/rolling_file_appender/rolling_file_appender.go
+++ b/v2/slogger/rolling_file_appender/rolling_file_appender.go
@@ -18,15 +18,15 @@
 package rolling_file_appender
 
 import (
-	"compress/gzip"
 	"github.com/mongodb/slogger/v2/slogger"
-	"io"
-	"strings"
 
+	"compress/gzip"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 )

--- a/v2/slogger/rolling_file_appender/rolling_file_appender_test.go
+++ b/v2/slogger/rolling_file_appender/rolling_file_appender_test.go
@@ -227,10 +227,7 @@ func TestCompressionOnRotation(test *testing.T) {
 	appender.maxUncompressedLogs = 1
 	defer appender.Close()
 
-	compressibleMessage := "This string is easily compressible"
-	for i := 0; i < 10; i++ {
-		compressibleMessage += compressibleMessage
-	}
+	compressibleMessage := strings.Repeat("This string is easily compressible", 1000)
 
 	_, errs := logger.Logf(slogger.WARN, compressibleMessage)
 	AssertNoErrors(test, errs)

--- a/v2/slogger/rolling_file_appender/rotation_time.go
+++ b/v2/slogger/rolling_file_appender/rotation_time.go
@@ -31,7 +31,7 @@ func (self RotationTimeSlice) Swap(i, j int) {
 	self[i], self[j] = self[j], self[i]
 }
 
-var rotatedTimeRegExp = regexp.MustCompile(`\.(\d+-\d\d-\d\dT\d\d-\d\d-\d\d)(-(\d+))?$`)
+var rotatedTimeRegExp = regexp.MustCompile(`\.(\d+-\d\d-\d\dT\d\d-\d\d-\d\d)(-(\d+))?(.gz)?$`)
 
 func extractRotationTimeFromFilename(filename string) (*RotationTime, error) {
 	match := rotatedTimeRegExp.FindStringSubmatch(filename)

--- a/v2/slogger/rolling_file_appender/rotation_time.go
+++ b/v2/slogger/rolling_file_appender/rotation_time.go
@@ -31,7 +31,7 @@ func (self RotationTimeSlice) Swap(i, j int) {
 	self[i], self[j] = self[j], self[i]
 }
 
-var rotatedTimeRegExp = regexp.MustCompile(`\.(\d+-\d\d-\d\dT\d\d-\d\d-\d\d)(-(\d+))?(.gz)?$`)
+var rotatedTimeRegExp = regexp.MustCompile(`\.(\d+-\d\d-\d\dT\d\d-\d\d-\d\d)(-(\d+))?(\.gz)?$`)
 
 func extractRotationTimeFromFilename(filename string) (*RotationTime, error) {
 	match := rotatedTimeRegExp.FindStringSubmatch(filename)


### PR DESCRIPTION
Create an internal builder for setting options on the rolling_file_appender and add the ability to compress logs on rotation

go test shows all tests as passing