### PR TITLE
Add ability to pass in custom formatter function to RollingFileAppender

### DIFF
--- a/v2/slogger/rolling_file_appender/rolling_file_appender.go
+++ b/v2/slogger/rolling_file_appender/rolling_file_appender.go
@@ -105,7 +105,7 @@ func New(filename string, maxFileSize int64, maxDuration time.Duration, maxRotat
 	return NewWithStringWriter(filename, maxFileSize, maxDuration, maxRotatedLogs, rotateIfExists, headerGenerator, nil)
 }
 
-func NewWithLogFormatter(filename string, maxFileSize int64, maxDuration time.Duration, maxRotatedLogs int, rotateIfExists bool, headerGenerator func() []string, formatLogFunc func () func (*slogger.Log) string) (*RollingFileAppender, error) {
+func NewWithLogFormatter(filename string, maxFileSize int64, maxDuration time.Duration, maxRotatedLogs int, rotateIfExists bool, headerGenerator func() []string, formatLogFunc func() func(*slogger.Log) string) (*RollingFileAppender, error) {
 	return newRollingFileAppender(filename, maxFileSize, maxDuration, maxRotatedLogs, rotateIfExists, headerGenerator, nil, formatLogFunc)
 }
 
@@ -113,7 +113,7 @@ func NewWithStringWriter(filename string, maxFileSize int64, maxDuration time.Du
 	return newRollingFileAppender(filename, maxFileSize, maxDuration, maxRotatedLogs, rotateIfExists, headerGenerator, stringWriterCallback, nil)
 }
 
-func newRollingFileAppender(filename string, maxFileSize int64, maxDuration time.Duration, maxRotatedLogs int, rotateIfExists bool, headerGenerator func() []string, stringWriterCallback func(*os.File) slogger.StringWriter, formatLogFunc func () func (*slogger.Log) string) (*RollingFileAppender, error) {
+func newRollingFileAppender(filename string, maxFileSize int64, maxDuration time.Duration, maxRotatedLogs int, rotateIfExists bool, headerGenerator func() []string, stringWriterCallback func(*os.File) slogger.StringWriter, formatLogFunc func() func(*slogger.Log) string) (*RollingFileAppender, error) {
 	if headerGenerator == nil {
 		headerGenerator = func() []string {
 			return []string{}
@@ -125,7 +125,7 @@ func newRollingFileAppender(filename string, maxFileSize int64, maxDuration time
 		}
 	}
 
-	if (formatLogFunc == nil) {
+	if formatLogFunc == nil {
 		formatLogFunc = slogger.GetFormatLogFunc
 	}
 

--- a/v2/slogger/rolling_file_appender/rolling_file_appender_test.go
+++ b/v2/slogger/rolling_file_appender/rolling_file_appender_test.go
@@ -222,7 +222,7 @@ func TestCustomLogFormatFunc(test *testing.T) {
 	defer teardown()
 
 	createLogDir(test)
-	appender, err := NewWithStringWriter(
+	appender, err := NewWithLogFormatter(
 		rfaTestLogPath,
 		-1,
 		0,
@@ -231,8 +231,11 @@ func TestCustomLogFormatFunc(test *testing.T) {
 		func() []string {
 			return []string{}
 		},
-		nil,
-		func(log *slogger.Log) string { return log.Message() },
+		func() func(*slogger.Log) string {
+			return func(log *slogger.Log) (string) {
+				return log.Message()
+			}
+		},
 	)
 
 	if err != nil {

--- a/v2/slogger/rolling_file_appender/rolling_file_appender_test.go
+++ b/v2/slogger/rolling_file_appender/rolling_file_appender_test.go
@@ -232,7 +232,7 @@ func TestCustomLogFormatFunc(test *testing.T) {
 			return []string{}
 		},
 		func() func(*slogger.Log) string {
-			return func(log *slogger.Log) (string) {
+			return func(log *slogger.Log) string {
 				return log.Message()
 			}
 		},


### PR DESCRIPTION
This PR adds the ability to pass in a custom log formatting string to `RollingFileAppender`.