### PR TITLE
CLOUDP-142353: Skip over the first level of the stack while calling runtime.Caller

### DIFF
--- a/v2/slogger/logger.go
+++ b/v2/slogger/logger.go
@@ -229,7 +229,7 @@ func containsAnyIgnoredFilename(s string) bool {
 }
 
 func nonSloggerCaller() (pc uintptr, file string, line int, ok bool) {
-	for skip := 0; skip < 100; skip++ {
+	for skip := 1; skip < 100; skip++ {
 		pc, file, line, ok := runtime.Caller(skip)
 		if !ok || !containsAnyIgnoredFilename(file) {
 			return pc, file, line, ok


### PR DESCRIPTION
`logger.go` within v2 slogger is already [added](https://github.com/mongodb/slogger/blob/9de452b71558d6c7743493269c02637c0fc1a431/v2/slogger/logger.go#L191) to the list of ignored files. Calling `runtime.Caller(0)` is useless because it's guaranteed to be skipped over. The loop variable can safely be incremented to start from 1 instead of 0, thereby saving a call to `runtime.Caller` for every log statement.

QA: Ran `./run-tests` and everything in v1 and v2 passed.

cc @dunkyboy @alex-dambrouski