### PR TITLE
Skip 2 levels instead of 1 while evaluating nonSloggerCaller

### DIFF
--- a/v2/slogger/logger.go
+++ b/v2/slogger/logger.go
@@ -229,7 +229,8 @@ func containsAnyIgnoredFilename(s string) bool {
 }
 
 func nonSloggerCaller() (pc uintptr, file string, line int, ok bool) {
-	for skip := 1; skip < 100; skip++ {
+	// Skip the stack frame for `nonSloggerCaller()` and `logf(...)`
+	for skip := 2; skip < 100; skip++ {
 		pc, file, line, ok := runtime.Caller(skip)
 		if !ok || !containsAnyIgnoredFilename(file) {
 			return pc, file, line, ok
@@ -238,6 +239,8 @@ func nonSloggerCaller() (pc uintptr, file string, line int, ok bool) {
 	return 0, "", 0, false
 }
 
+// DO NOT MAKE FUNCTION PUBLIC! `nonSloggerCaller()` relies on the order of stack frames
+// laid out to skip the evaluation for `runtime.Caller(...)` a few times.
 func (self *Logger) logf(level Level, errorCode ErrorCode, messageFmt string, context *Context, args ...interface{}) (*Log, []error) {
 	var errors []error
 

--- a/v2/slogger/logger.go
+++ b/v2/slogger/logger.go
@@ -228,8 +228,12 @@ func containsAnyIgnoredFilename(s string) bool {
 	return false
 }
 
+/*
+DO NOT MAKE FUNCTION PUBLIC! Keeping this private lets us skip the stack frames for
+this function and the function in this package that calls `nonSloggerCaller()`, therefore
+allowing us to set the skip=2 in the loop below.
+*/
 func nonSloggerCaller() (pc uintptr, file string, line int, ok bool) {
-	// Skip the stack frame for `nonSloggerCaller()` and `logf(...)`
 	for skip := 2; skip < 100; skip++ {
 		pc, file, line, ok := runtime.Caller(skip)
 		if !ok || !containsAnyIgnoredFilename(file) {
@@ -239,8 +243,6 @@ func nonSloggerCaller() (pc uintptr, file string, line int, ok bool) {
 	return 0, "", 0, false
 }
 
-// DO NOT MAKE FUNCTION PUBLIC! `nonSloggerCaller()` relies on the order of stack frames
-// laid out to skip the evaluation for `runtime.Caller(...)` a few times.
 func (self *Logger) logf(level Level, errorCode ErrorCode, messageFmt string, context *Context, args ...interface{}) (*Log, []error) {
 	var errors []error
 


### PR DESCRIPTION
Skipping one level would put us in the stack frame for `logf(...)`, which is an internal function and can be skipped over too. 

QA: Ran tests and they were good.

cc @dunkyboy @alex-dambrouski