### PR TITLE
Evaluate message formatting only once while formatting the log

### DIFF
--- a/v2/slogger/logger.go
+++ b/v2/slogger/logger.go
@@ -36,6 +36,10 @@ type Log struct {
 	MessageFmt string
 	Args       []interface{}
 	Context    *Context
+
+	// Appendages to evaluate a message only once
+	message string
+	evalMsgOnce sync.Once
 }
 
 func SimpleLog(prefix string, level Level, errorCode ErrorCode, callerSkip int, messageFmt string, args ...interface{}) *Log {
@@ -101,7 +105,10 @@ func getTruncatedMessage(old string) string {
 }
 
 func (self *Log) Message() string {
-	return getTruncatedMessage(fmt.Sprintf(self.MessageFmt, self.Args...))
+	self.evalMsgOnce.Do(func() {
+		self.message = getTruncatedMessage(fmt.Sprintf(self.MessageFmt, self.Args...))
+	})
+	return self.message
 }
 
 type Logger struct {


### PR DESCRIPTION
`log.Message()` can be called multiple times after the `Log` object has been constructed, and each time it'll print the formatted over and over again. This PR introduces a way in which evaluation happens once, and the formatted log is stored in the `Log` and is returned without any cost.

QA: `./run-tests` shows everything in v2 passing.

cc @dunkyboy