### PR TITLE
Fix log truncation

### DIFF
--- a/v2/slogger/logger.go
+++ b/v2/slogger/logger.go
@@ -95,7 +95,11 @@ func getTruncatedMessage(old string) string {
 	lineLen := len(old)
 	mls := getMaxLogSize()
 	if mls > MinimumMaxLogSizeThreshold && lineLen > mls+4 {
-		new = fmt.Sprintf("%s...%s (warning: log line attempted (%vk) over max size (%vk), printing beginning and end)", old[0:mls], old[lineLen+3-MinimumMaxLogSizeThreshold:], getSizeInKb(lineLen), getSizeInKb(mls))
+		new = fmt.Sprintf("%s...%s (warning: log line attempted (%vk) over max size (%vk), printing beginning and end)",
+			old[0:mls/2],
+			old[lineLen-mls/2:],
+			getSizeInKb(lineLen),
+			getSizeInKb(mls))
 	}
 	return new
 }

--- a/v2/slogger/logger_test.go
+++ b/v2/slogger/logger_test.go
@@ -300,7 +300,7 @@ func TestTruncation(t *testing.T) {
 		}
 	}
 	// no truncation
-	msg := "Please disregard the imminent warning. This is just a test. Please disregard the imminent warning. This is just a test. Please disregard the imminent warning. This is just a test. This is just a test. Please disregard the imminent warning. This is just a test. Please disregard the imminent warning. This is just a test. This is just a test. Please disregard the imminent warning. This is just a test. Please disregard the imminent warning. This is just a test."
+	msg := "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum fermentum, dolor a semper consectetur, purus felis auctor neque, ac pellentesque lectus est sed ipsum. Nunc nec elementum elit nunc."
 	check(msg, msg)
 
 	// set threshold below 100 (the minimum) - no truncation
@@ -312,7 +312,7 @@ func TestTruncation(t *testing.T) {
 
 	// set threshold to 110
 	SetMaxLogSize(110)
-	check(msg, "This is jus...mminent warning")
+	check(msg, "Lorem ipsum dolor sit amet, consectetur adipiscing elit...que lectus est sed ipsum. Nunc nec elementum elit nunc.")
 
 }
 


### PR DESCRIPTION
Whenever the entry size exceeds the threshold (say, 10kb), slogger truncates the entry and prints the beginning and end of the message. However it's currently mostly printing the beginning of the message and only a tiny bit of the ending which prevents us from seeing useful information.

This PR changes to print an equal amount of bytes from the start and from the end so that a 20KB entry would show the first 5KB and last 5KB (if the threshold is 10KB).
